### PR TITLE
Add is valid check for a phone number string and multiple regions

### DIFF
--- a/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
+++ b/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
@@ -43,6 +43,15 @@ namespace PhoneNumbers.Test
             wrongTypeCases.Clear();
         }
 
+        [Test]
+        public void TestParse()
+        {
+            var phoneNumber = phoneNumberUtil.Parse("410-978-2234");
+            var isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+
+            Assert.IsTrue(isValid);
+        }
+
         /**
         * @param exampleNumberRequestedType  type we are requesting an example number for
         * @param possibleExpectedTypes       acceptable types that this number should match, such as

--- a/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
+++ b/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
@@ -44,12 +44,15 @@ namespace PhoneNumbers.Test
         }
 
         [Test]
-        public void TestParse()
+        public void TestParseMultipleRegions()
         {
-            var phoneNumber = phoneNumberUtil.Parse("410-978-2234");
-            var isValid = phoneNumberUtil.IsValidNumber(phoneNumber);
+            var usPhoneNumber = "14109992222";
+            var canadaPhoneNumber = "14039782234";
+            var usValid = phoneNumberUtil.IsValidNumber(usPhoneNumber, new List<string>() { "US", "CA" });
+            var canadaValid = phoneNumberUtil.IsValidNumber(canadaPhoneNumber, new List<string>() { "US", "CA" });
 
-            Assert.IsTrue(isValid);
+            Assert.IsTrue(usValid);
+            Assert.IsTrue(canadaValid);
         }
 
         /**

--- a/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
+++ b/csharp/PhoneNumbers.Test/TestExampleNumbers.cs
@@ -48,11 +48,17 @@ namespace PhoneNumbers.Test
         {
             var usPhoneNumber = "14109992222";
             var canadaPhoneNumber = "14039782234";
-            var usValid = phoneNumberUtil.IsValidNumber(usPhoneNumber, new List<string>() { "US", "CA" });
-            var canadaValid = phoneNumberUtil.IsValidNumber(canadaPhoneNumber, new List<string>() { "US", "CA" });
+            String matchedUsRegionCode;
+            String matchedCanadianRegionCode;
+            
+            // Tests
+            var usValid = phoneNumberUtil.IsValidNumber(usPhoneNumber, new List<string>() { "US", "CA" }, out matchedUsRegionCode);
+            var canadaValid = phoneNumberUtil.IsValidNumber(canadaPhoneNumber, new List<string>() { "US", "CA" }, out matchedCanadianRegionCode);
 
             Assert.IsTrue(usValid);
             Assert.IsTrue(canadaValid);
+            Assert.AreEqual(matchedUsRegionCode, "US");
+            Assert.AreEqual(matchedCanadianRegionCode, "CA");
         }
 
         /**

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -1961,13 +1961,17 @@ namespace PhoneNumbers
         }
 
         /// <summary>
-        /// Checks to see if the given phone number is valid for one of the regionCodes
+        /// Checks to see if the given phone number is valid for one of the regionCodes. If valid, matchedRegionCode will be populated
+        /// with the matched region code for the valid phone number.
         /// </summary>
         /// <param name="phoneNumber"></param>
         /// <param name="regionCodes"></param>
+        /// <param name="matchedRegionCode">If a valid number, this will be populated with the matching region code.</param>
         /// <returns>True if valid, false if not (or not able to parse phone number based on one of the regions)</returns>
-        public bool IsValidNumber(String phoneNumber, IList<String> regionCodes)
+        public bool IsValidNumber(String phoneNumber, IList<String> regionCodes, out String matchedRegionCode)
         {
+            matchedRegionCode = String.Empty;
+
             if (regionCodes == null || regionCodes.Count == 0)
                 return false;
 
@@ -1978,7 +1982,10 @@ namespace PhoneNumbers
                 if (pn != null)
                 {
                     if (IsValidNumberForRegion(pn, regionCode))
+                    {
+                        matchedRegionCode = regionCode;
                         phoneNumbers.Add(pn);
+                    }
                 }
             }
 

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -1942,6 +1942,49 @@ namespace PhoneNumbers
             return possibleNumberPatternMatch.Success && nationalNumberPatternMatch.Success;
         }
 
+        /// <summary>
+        /// Checks to see if the given phone number is valid for the given regionCode
+        /// </summary>
+        /// <param name="phoneNumber"></param>
+        /// <param name="regionCode"></param>
+        /// <returns>True if valid, false if not (or not able to parse phone number based on region)</returns>
+        public bool IsValidNumber(String phoneNumber, String regionCode)
+        {
+            if (String.IsNullOrEmpty(regionCode))
+                return false;
+
+            var pn = Parse(phoneNumber, regionCode);
+            if (pn != null)            
+                return IsValidNumberForRegion(pn, regionCode);
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks to see if the given phone number is valid for one of the regionCodes
+        /// </summary>
+        /// <param name="phoneNumber"></param>
+        /// <param name="regionCodes"></param>
+        /// <returns>True if valid, false if not (or not able to parse phone number based on one of the regions)</returns>
+        public bool IsValidNumber(String phoneNumber, IList<String> regionCodes)
+        {
+            if (regionCodes == null || regionCodes.Count == 0)
+                return false;
+
+            var phoneNumbers = new List<PhoneNumber>();
+            foreach (var regionCode in regionCodes)
+            {
+                var pn = Parse(phoneNumber, regionCode);
+                if (pn != null)
+                {
+                    if (IsValidNumberForRegion(pn, regionCode))
+                        phoneNumbers.Add(pn);
+                }
+            }
+
+            return phoneNumbers.Count > 0;
+        }
+
         /**
         * Tests whether a phone number matches a valid pattern. Note this doesn't verify the number
         * is actually in use, which is impossible to tell by just looking at a number itself.


### PR DESCRIPTION
This will allow someone to take input from a form and a single region code (or a list of region codes) that is whitelisted by their application and validate that the phone number is valid for that region or regions. An example would be someone enters a US number and the form should accept US and Canadian numbers. They can now validate against that easily.
