### PR TITLE
PhoneNumberUtil.GetInstance() - avoid locking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ build/
 *.pidb
 *.log
 *.scc
+*/.vs/*
 
 # Visual C++ cache files
 ipch/

--- a/csharp/PhoneNumbers/PhoneNumberUtil.cs
+++ b/csharp/PhoneNumbers/PhoneNumberUtil.cs
@@ -857,6 +857,14 @@ namespace PhoneNumbers
         public static PhoneNumberUtil GetInstance(String baseFileLocation,
             Dictionary<int, List<String>> countryCallingCodeToRegionCodeMap)
         {
+            //double-check on purpose to avoid locking
+            //Storing value in a temp variable first, because it can get reset to null.
+            var i = instance_;
+            if (i != null)
+            {
+                return i;
+            }
+
             lock (thisLock)
             {
                 if (instance_ == null)
@@ -909,6 +917,14 @@ namespace PhoneNumbers
         */
         public static PhoneNumberUtil GetInstance()
         {
+            //double-check on purpose to avoid locking
+            //Storing value in a temp variable first, because it can get reset to null.
+            var i = instance_;
+            if (i != null)
+            {
+                return i;
+            }
+
             lock (thisLock)
             {
                 if (instance_ == null)


### PR DESCRIPTION
This change will avoid locking (and switching thread context) in a multi-threaded environment, when PhoneNumberUtil.GetInstance() is called.
It will still lock when the instance is not initialized yet.